### PR TITLE
Remove www from Twitter and GitHub links.

### DIFF
--- a/client/app/templates/application.hbs
+++ b/client/app/templates/application.hbs
@@ -19,9 +19,9 @@
                     </p>
                     <p>
                         Key contributors:
-                        <a href="http://www.twitter.com/og">@og</a>,
-                        <a href="http://www.twitter.com/amandeep">@amandeep</a>.
-                        <a href="http://www.github.com/engsciclub/website">Contribute.</a>
+                        <a href="http://twitter.com/og">@og</a>,
+                        <a href="http://twitter.com/amandeep">@amandeep</a>.
+                        <a href="http://github.com/engsciclub/website">Contribute.</a>
                     </p>
                 </footer>
             {{/view}}


### PR DESCRIPTION
No need to have www
